### PR TITLE
Example PR with 1 commit opened before formatting

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -6053,6 +6053,7 @@ bool OMR::ValuePropagation::prepareForBlockVersion(TR_LinkHead<ArrayLengthToVers
          }
 
     TR_OpaqueClassBlock *instanceOfClass = NULL;
+    TR_OpaqueClassBlock *indexInstanceOfClass = NULL;
 
       //check if aloads are invariants
     if (!arrayLen->getOpCode().isLoadDirect())
@@ -6185,9 +6186,21 @@ bool OMR::ValuePropagation::prepareForBlockVersion(TR_LinkHead<ArrayLengthToVers
       if (!shouldAnalyze)
          continue;
 
+      if(baseNode && baseNode->getOpCode().getOpCodeValue() == TR::iloadi)
+         {
+         // Get the class of the field
+         int32_t len;
+         TR::SymbolReference *symRefField = baseNode->getSymbolReference();
+         char *sig = symRefField->getOwningMethod(comp())->classNameOfFieldOrStatic(symRefField->getCPIndex(), len);
+         TR_OpaqueClassBlock *classOfField = (sig)?fe()->getClassFromSignature(sig, len,symRefField->getOwningMethod(comp())):NULL;
+         if (!classOfField)
+            continue;
+         indexInstanceOfClass = classOfField;
+         }
+
       if (!array )
          {
-         createNewBucketForArrayIndex(array, arrayLengths, c, baseNode, bndchkNode, instanceOfClass);
+         createNewBucketForArrayIndex(array, arrayLengths, c, baseNode, bndchkNode, instanceOfClass, indexInstanceOfClass);
          continue;
          }
 
@@ -6299,7 +6312,7 @@ bool OMR::ValuePropagation::prepareForBlockVersion(TR_LinkHead<ArrayLengthToVers
          }//if arrayIndexInfoFound
       else
          {
-         createNewBucketForArrayIndex(array, arrayLengths, c, baseNode, bndchkNode, instanceOfClass);
+         createNewBucketForArrayIndex(array, arrayLengths, c, baseNode, bndchkNode, instanceOfClass, indexInstanceOfClass);
          continue; //next bndchk
          }
 
@@ -6367,7 +6380,6 @@ void OMR::ValuePropagation::buildBoundCheckComparisonNodes(BlockVersionInfo *blo
 
             if (arrayIndex->_baseNode)
                {
-
                maxIndex = TR::Node::create(TR::iadd,2, arrayIndex->_baseNode->duplicateTree(), TR::Node::create(arrayLength->_arrayLen,TR::iconst, 0, arrayIndex->_max));
                minIndex = TR::Node::create(TR::iadd,2, arrayIndex->_baseNode->duplicateTree(), TR::Node::create(arrayLength->_arrayLen,TR::iconst, 0, arrayIndex->_min));
                }
@@ -6393,6 +6405,23 @@ void OMR::ValuePropagation::buildBoundCheckComparisonNodes(BlockVersionInfo *blo
                traceMsg(comp(), "Second test - Creating %p (%s)\n", nextComparisonNode, nextComparisonNode->getOpCode().getName());
 
             temp.add(nextComparisonNode);
+
+            if (arrayIndex->_baseNode && arrayIndex->_instanceOfClass && !comp()->compileRelocatableCode() && 
+                arrayIndex->_baseNode->getOpCode().getOpCodeValue() == TR::iloadi)
+               {
+               // InstanceOf check for the object were we load the array index from
+               TR::Node *objectRefChild = arrayIndex->_baseNode->getFirstChild();
+               if (objectRefChild)
+                  {
+                  dumpOptDetails(comp(), "%s Creating test for instanceof of %p outside block_%d for versioning array index %p \n", OPT_DETAILS, objectRefChild, blockInfo->_block->getNumber(), arrayIndex->_baseNode);
+                  TR::Node *duplicateClassPtr = TR::Node::createWithSymRef(objectRefChild, TR::loadaddr, 0, comp()->getSymRefTab()->findOrCreateClassSymbol(arrayIndex->_baseNode->getSymbolReference()->getOwningMethodSymbol(comp()), -1, arrayIndex->_instanceOfClass, false));
+                  TR::Node *instanceofNode = TR::Node::createWithSymRef(TR::instanceof, 2, 2, objectRefChild->duplicateTree(),  duplicateClassPtr, comp()->getSymRefTab()->findOrCreateInstanceOfSymbolRef(comp()->getMethodSymbol()));
+                  TR::Node *ificmpeqNode =  TR::Node::createif(TR::ificmpeq, instanceofNode, TR::Node::create(arrayIndex->_baseNode, TR::iconst, 0, 0));
+                  temp.add(ificmpeqNode);
+                  requestOpt(OMR::localCSE,  true);
+                  requestOpt(OMR::localValuePropagation,  true);
+                  }
+               }
             }
          }
       if (arrayLengthVersioned)
@@ -6576,7 +6605,7 @@ TR::Node *OMR::ValuePropagation::findVarOfSimpleForm(TR::Node *node) //ArrayInde
    }
 
 
-void OMR::ValuePropagation::createNewBucketForArrayIndex(ArrayLengthToVersion *array, TR_LinkHead<ArrayLengthToVersion> *arrayLengths, int32_t c, TR::Node *baseNode, TR::Node *bndchkNode, TR_OpaqueClassBlock *instanceOfClass)
+void OMR::ValuePropagation::createNewBucketForArrayIndex(ArrayLengthToVersion *array, TR_LinkHead<ArrayLengthToVersion> *arrayLengths, int32_t c, TR::Node *baseNode, TR::Node *bndchkNode, TR_OpaqueClassBlock *instanceOfClass, TR_OpaqueClassBlock *indexInstanceOfClass)
    {
    if (!array )
       {         //create a new arrayLengthToVersion
@@ -6592,6 +6621,7 @@ void OMR::ValuePropagation::createNewBucketForArrayIndex(ArrayLengthToVersion *a
    arrayIndex->_max = c;
    arrayIndex->_delta = 0;
    arrayIndex->_baseNode = baseNode;
+   arrayIndex->_instanceOfClass = indexInstanceOfClass;
    arrayIndex->_bndChecks = new (trStackMemory()) TR_ScratchList<TR::Node>(trMemory());
    arrayIndex->_bndChecks->add(bndchkNode);
    arrayIndex->_versionBucket= false;

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -788,6 +788,7 @@ class ValuePropagation : public TR::Optimization
       bool _versionBucket;
       bool _notToVersionBucket;
       TR_ScratchList<TR::Node> *_bndChecks;
+      TR_OpaqueClassBlock *_instanceOfClass;
       };
    struct ArrayLengthToVersion : public TR_Link<ArrayLengthToVersion>
       {
@@ -814,7 +815,7 @@ class ValuePropagation : public TR::Optimization
    void removeBndChecksFromFastVersion(BlockVersionInfo *);
    TR::Node * findVarOfSimpleForm(TR::Node *);
    TR::Node * findVarOfSimpleFormOld(TR::Node *);
-   void createNewBucketForArrayIndex(ArrayLengthToVersion *,TR_LinkHead<ArrayLengthToVersion> *, int32_t , TR::Node *, TR::Node *, TR_OpaqueClassBlock *);
+   void createNewBucketForArrayIndex(ArrayLengthToVersion *,TR_LinkHead<ArrayLengthToVersion> *, int32_t , TR::Node *, TR::Node *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *);
    void collectDefSymRefs(TR::Node *,TR::Node *);
    bool prepareForBlockVersion(TR_LinkHead<ArrayLengthToVersion> *);
    void addToSortedList(TR_LinkHead<ArrayLengthToVersion> *,ArrayLengthToVersion *);


### PR DESCRIPTION
When versioning blocks, it's possible for the generated checks to load
index variables from objects by duplicating code from within blocks that
are protected by inlining guards. Therefore the object might not be of
the expected type possibly resulting in loads that reach past the end
of the object. In rare cases this load can result in a SEGV when the
object is allocated at the very end of the heap.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>